### PR TITLE
Fix casting error.

### DIFF
--- a/core/src/main/java/com/onloupe/agent/metrics/SampledMetric.java
+++ b/core/src/main/java/com/onloupe/agent/metrics/SampledMetric.java
@@ -384,7 +384,8 @@ public final class SampledMetric {
 			} else if (dataBinding.getValue().equals(MemberType.METHOD)) {
 				Method method = userDataType.getMethod(dataBinding.getName());
 				method.setAccessible(true);
-				numerator = (double)method.invoke(metricData);
+				Object output = method.invoke(metricData);
+				numerator = Double.parseDouble(output.toString());
 			}
 
 			if (SampledMetricDefinition.requiresDivisor(getSamplingType())) {
@@ -400,7 +401,8 @@ public final class SampledMetric {
 				} else if (divisorBinding.getValue().equals(MemberType.METHOD)) {
 					Method method = userDataType.getMethod(divisorBinding.getName());
 					method.setAccessible(true);
-					rawDivisor = (double)method.invoke(metricData);
+					Object output = method.invoke(metricData);
+					rawDivisor = Double.parseDouble(output.toString());
 				}
 				
 				writeSample(numerator, rawDivisor); // Write the pair of values.

--- a/core/src/main/java/com/onloupe/agent/metrics/SampledMetric.java
+++ b/core/src/main/java/com/onloupe/agent/metrics/SampledMetric.java
@@ -385,7 +385,7 @@ public final class SampledMetric {
 				Method method = userDataType.getMethod(dataBinding.getName());
 				method.setAccessible(true);
 				Object output = method.invoke(metricData);
-				numerator = Double.parseDouble(output.toString());
+				numerator = TypeUtils.strictDouble(output);
 			}
 
 			if (SampledMetricDefinition.requiresDivisor(getSamplingType())) {
@@ -402,14 +402,15 @@ public final class SampledMetric {
 					Method method = userDataType.getMethod(divisorBinding.getName());
 					method.setAccessible(true);
 					Object output = method.invoke(metricData);
-					rawDivisor = Double.parseDouble(output.toString());
+					rawDivisor = TypeUtils.strictDouble(output);
 				}
 				
 				writeSample(numerator, rawDivisor); // Write the pair of values.
 			} else {
-				writeSample(numerator); // Write the single data value.
+				writeSample(numerator.doubleValue()); // Write the single data value.
 			}
 		} catch (java.lang.Exception e) {
+			e.printStackTrace();
 
 			// We can't write this sample if we got an error reading the data.
 		}

--- a/core/src/main/java/com/onloupe/agent/metrics/SampledMetric.java
+++ b/core/src/main/java/com/onloupe/agent/metrics/SampledMetric.java
@@ -410,8 +410,6 @@ public final class SampledMetric {
 				writeSample(numerator.doubleValue()); // Write the single data value.
 			}
 		} catch (java.lang.Exception e) {
-			e.printStackTrace();
-
 			// We can't write this sample if we got an error reading the data.
 		}
 	}

--- a/core/src/main/java/com/onloupe/core/util/TypeUtils.java
+++ b/core/src/main/java/com/onloupe/core/util/TypeUtils.java
@@ -339,6 +339,26 @@ public class TypeUtils {
 		}
 		return 0d;
 	}
+	
+	public static double strictDouble(Object value) {		
+		if (value != null) {
+			if (Double.class.isAssignableFrom(value.getClass()))
+				return (double) value;
+			if (value instanceof Short)
+				return ((Short) value).doubleValue();
+			if (value instanceof Integer)
+				return ((Integer) value).doubleValue();
+			if (value instanceof Long)
+				return ((Long) value).doubleValue();
+			if (value instanceof Float)
+				return ((Float) value).doubleValue();
+			if (value instanceof BigDecimal)
+				return ((BigDecimal) value).doubleValue();
+			if (value instanceof BigInteger)
+				return ((BigInteger) value).doubleValue();
+		}
+		throw new IllegalArgumentException("Argument " + value + " is not a parseable double.");
+	}
 
 	/**
 	 * Safe UUID.
@@ -386,4 +406,5 @@ public class TypeUtils {
 		}
 		throw new IndexOutOfBoundsException("Unsupported type " + type == null ? null : type.getName());
 	}
+	
 }


### PR DESCRIPTION
Despite the value of an int always being valid as the value of a double (though higher numbers can exceed its capacity), java does not allow the direct casting of an int to a double.

We must instead get the result object from the method invocation, extract the value to a string, and then attempt to parse that string into a double. 